### PR TITLE
Setting year when month has been clicked.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -553,6 +553,7 @@ const Calendar = (props) => {
 				if (selector === 'month') {
 					let _selected = selected
 					_selected.setMonth(month, 1)
+					_selected.setYear(year)
 					setDate(_selected)
 				} else {
 					setView('day')


### PR DESCRIPTION
Firstly thanks for contributing such a great package. I couldn't find any alternatives which used modern React hooks. Great job!

I think this change makes sense, when the user navigates to a different year and clicks on a month, the year should change too.

My main concern with this change is that it doesn't leverage the "selector" which is setup to explicitly only set what is configured. Would you consider having multiple selectors? See below for context:
```
function isMonthSelector(selector: string) {
  return selector.includes("month");
}
function isYearSelector(selector: string) {
  return selector.includes("year");
}

<DateTimePicker selector="month|year" />
```

Then in `onMonthClick`:
```
let _selected = selected;
if (isMonthSelector(selector)) {
  _selected.setMonth(month, 1)
}
if (isYearSelector(selector)) {
  _selected.setYear(year)
}
setDate(_selected)
```